### PR TITLE
課題：Micropost のお気に入り機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,3 +57,5 @@ gem 'kaminari'
 gem 'html2slim'
 
 gem 'slim-rails'
+
+gem 'font-awesome-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,6 +55,8 @@ GEM
     erubis (2.7.0)
     execjs (2.7.0)
     ffi (1.9.25)
+    font-awesome-rails (4.7.0.4)
+      railties (>= 3.2, < 6.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hpricot (0.8.6)
@@ -186,6 +188,7 @@ DEPENDENCIES
   bcrypt (~> 3.1.7)
   byebug
   coffee-rails (~> 4.2)
+  font-awesome-rails
   html2slim
   jbuilder (~> 2.5)
   jquery-rails

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -12,4 +12,5 @@
  *
  *= require_tree .
  *= require_self
+ *= require font-awesome
  */

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,5 +14,6 @@ class ApplicationController < ActionController::Base
     @count_microposts = user.microposts.count
     @count_followings = user.followings.count
     @count_followers = user.followers.count
+    @count_like_microposts = user.liked_microposts.count
   end
 end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,0 +1,10 @@
+class LikesController < ApplicationController
+  def create
+    @micropost = Micropost.find(params[:micropost_id])
+    current_user.like_micropost(@micropost)
+    respond_to :js
+  end
+
+  def destroy
+  end
+end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -1,10 +1,19 @@
 class LikesController < ApplicationController
+  before_action :require_user_logged_in
+  before_action :set_micropost
+
   def create
-    @micropost = Micropost.find(params[:micropost_id])
     current_user.like_micropost(@micropost)
     respond_to :js
   end
 
   def destroy
+    current_user.unlike_micropost(@micropost)
+    respond_to :js
+  end
+
+  private
+  def set_micropost
+    @micropost = Micropost.find(params[:micropost_id])
   end
 end

--- a/app/controllers/microposts_controller.rb
+++ b/app/controllers/microposts_controller.rb
@@ -5,7 +5,7 @@ class MicropostsController < ApplicationController
   def create
     @micropost = current_user.microposts.build(micropost_params)
     if @micropost.save
-      flash[:success] = 'メッセージの投稿に失敗しました'
+      flash[:success] = 'メッセージの投稿に成功しました'
       redirect_to root_url
     else
       @microposts = current_user.feed_microposts.order('created_at DESC').page(params[:page])

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   before_action :require_user_logged_in, only: [:index, :show]
+  before_action :set_user, only: [:show, :followings, :followers, :likes]
 
   def index
     @users = User.all.page(params[:page])
@@ -28,14 +29,17 @@ class UsersController < ApplicationController
   end
   
   def followings
-    @user = User.find(params[:id])
     @followings = @user.followings.page(params[:page])
     counts(@user)
   end
 
   def followers
-    @user = User.find(params[:id])
     @followers = @user.followers.page(params[:page])
+    counts(@user)
+  end
+
+  def likes
+    @microposts = @user.liked_microposts.page(params[:page])
     counts(@user)
   end
 
@@ -43,5 +47,9 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def set_user
+    @user = User.find(params[:id])
   end
 end

--- a/app/models/like.rb
+++ b/app/models/like.rb
@@ -1,0 +1,4 @@
+class Like < ApplicationRecord
+  belongs_to :user
+  belongs_to :micropost
+end

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,7 +1,7 @@
 class Micropost < ApplicationRecord
   belongs_to :user
 
-  has_many :likes
+  has_many :likes, dependent: :destroy
 
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 255 }

--- a/app/models/micropost.rb
+++ b/app/models/micropost.rb
@@ -1,6 +1,8 @@
 class Micropost < ApplicationRecord
   belongs_to :user
 
+  has_many :likes
+
   validates :user_id, presence: true
   validates :content, presence: true, length: { maximum: 255 }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
   has_many :reverses_of_relationship, class_name: 'Relationship', foreign_key: 'follow_id'
   has_many :followers, through: :reverses_of_relationship, source: :user
 
+  has_many :likes
+
   def follow(other_user)
     unless self == other_user
       self.relationships.find_or_create_by(follow_id: other_user.id)
@@ -30,5 +32,18 @@ class User < ApplicationRecord
 
   def feed_microposts
     Micropost.where(user_id: self.following_ids + [self.id])
+  end
+
+  def like_micropost(micropost)
+    self.likes.find_or_create_by(micropost_id: micropost.id)
+  end
+
+  def unlike_micropost(micropost)
+    like = self.likes.find_by(micropost_id: micropost.id)
+    like.destroy if like
+  end
+
+  def liked_micropost?(micropost)
+    self.likes.exists?(micropost_id: micropost.id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :followers, through: :reverses_of_relationship, source: :user
 
   has_many :likes
+  has_many :liked_microposts, through: :likes, source: :micropost
 
   def follow(other_user)
     unless self == other_user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,14 +6,14 @@ class User < ApplicationRecord
     format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i },
     uniqueness: { case_sensitive: false }
 
-  has_many :microposts
-  has_many :relationships
+  has_many :microposts, dependent: :destroy
+  has_many :relationships, dependent: :destroy
 
   has_many :followings, through: :relationships, source: :follow
   has_many :reverses_of_relationship, class_name: 'Relationship', foreign_key: 'follow_id'
   has_many :followers, through: :reverses_of_relationship, source: :user
 
-  has_many :likes
+  has_many :likes, dependent: :destroy
   has_many :liked_microposts, through: :likes, source: :micropost
 
   def follow(other_user)

--- a/app/views/layouts/_navbar.html.slim
+++ b/app/views/layouts/_navbar.html.slim
@@ -20,6 +20,8 @@ header
               ul.dropdown-menu
                 li
                   = link_to 'My profile', user_path(current_user)
+                li
+                  = link_to 'My Likes', likes_user_path(current_user)
                 li.divider role="separator"
                 li
                   = link_to 'Logout', logout_path, method: :delete

--- a/app/views/likes/_like_micropost.html.slim
+++ b/app/views/likes/_like_micropost.html.slim
@@ -1,11 +1,10 @@
-div id=("like_form_#{micropost.id}")
-  - if current_user.liked_micropost?(micropost)
-    = form_for(current_user.likes.find_by(micropost_id: micropost.id), remote: true, method: :delete) do |f|
-      = hidden_field_tag :micropost_id, micropost.id
-      = button_tag do
-        | aaa
-  - else
-    = form_for(current_user.likes.build, remote: true) do |f|
-      = hidden_field_tag :micropost_id, micropost.id
-      = button_tag do
-        = fa_icon("fal heart")
+- if current_user.liked_micropost?(micropost)
+  = form_for(current_user.likes.find_by(micropost_id: micropost.id), remote: true, method: :delete) do |f|
+    = hidden_field_tag :micropost_id, micropost.id
+    = button_tag do
+      = fa_icon "fal heart", class: "text-danger"
+- else
+  = form_for(current_user.likes.build, remote: true) do |f|
+    = hidden_field_tag :micropost_id, micropost.id
+    = button_tag do
+      = fa_icon "fal heart"

--- a/app/views/likes/_like_micropost.html.slim
+++ b/app/views/likes/_like_micropost.html.slim
@@ -1,0 +1,11 @@
+div id=("like_form_#{micropost.id}")
+  - if current_user.liked_micropost?(micropost)
+    = form_for(current_user.likes.find_by(micropost_id: micropost.id), remote: true, method: :delete) do |f|
+      = hidden_field_tag :micropost_id, micropost.id
+      = button_tag do
+        | aaa
+  - else
+    = form_for(current_user.likes.build, remote: true) do |f|
+      = hidden_field_tag :micropost_id, micropost.id
+      = button_tag do
+        = fa_icon("fal heart")

--- a/app/views/likes/create.js.slim
+++ b/app/views/likes/create.js.slim
@@ -1,0 +1,1 @@
+| $("#like_form_#{@micropost.id}").html("#{escape_javascript( render 'likes/like_micropost', micropost: @micropost)}");

--- a/app/views/likes/destroy.js.slim
+++ b/app/views/likes/destroy.js.slim
@@ -1,0 +1,1 @@
+| $("#like_form_#{@micropost.id}").html("#{escape_javascript( render 'likes/like_micropost', micropost: @micropost)}");

--- a/app/views/microposts/_microposts.html.slim
+++ b/app/views/microposts/_microposts.html.slim
@@ -14,7 +14,9 @@ ul.media-list
         div
           - if current_user == micropost.user
             = link_to "Delete", micropost, method: :delete, data: { confirm: "You sure?" }, class: 'btn btn-danger btn-xs'
-        div id=("like_form_#{micropost.id}")
-          = render "likes/like_micropost", micropost: micropost
+        
+        - unless current_page?(likes_user_path(current_user))
+          div id=("like_form_#{micropost.id}")
+            = render "likes/like_micropost", micropost: micropost
 
   = paginate microposts

--- a/app/views/microposts/_microposts.html.slim
+++ b/app/views/microposts/_microposts.html.slim
@@ -14,6 +14,7 @@ ul.media-list
         div
           - if current_user == micropost.user
             = link_to "Delete", micropost, method: :delete, data: { confirm: "You sure?" }, class: 'btn btn-danger btn-xs'
+        div id=("like_form_#{micropost.id}")
           = render "likes/like_micropost", micropost: micropost
 
   = paginate microposts

--- a/app/views/microposts/_microposts.html.slim
+++ b/app/views/microposts/_microposts.html.slim
@@ -14,5 +14,6 @@ ul.media-list
         div
           - if current_user == micropost.user
             = link_to "Delete", micropost, method: :delete, data: { confirm: "You sure?" }, class: 'btn btn-danger btn-xs'
+          = render "likes/like_micropost", micropost: micropost
 
   = paginate microposts

--- a/app/views/users/followers.html.slim
+++ b/app/views/users/followers.html.slim
@@ -9,22 +9,25 @@
     = render 'relationships/follow_button', user: @user
   .col-xs-8
     ul.nav.nav-tabs.nav-justified
-      - is_active = "active" if current_page?(user_path(@user))
-      - is_followings_active = "active" if current_page?(followings_user_path(@user))
-      - is_followers_active = "active" if current_page?(followers_user_path(@user))
-      li class=(is_active)
+      - is_active = "active" if current_page?(followers_user_path(@user))
+      li
         = link_to user_path(@user) do
           | Microposts
           span.badge
             = @count_microposts
-      li class=(is_followings_active)
+      li
         = link_to followings_user_path(@user) do
           | Followings
           span.badge
             = @count_followings
-      li class=(is_followers_active)
+      li class=(is_active)
         = link_to followers_user_path(@user) do
           | Followers
           span.badge
             = @count_followers
+      li
+        = link_to likes_user_path(@user) do
+          | Likes
+          span.badge
+            = @count_like_microposts
     = render 'users', users: @followers

--- a/app/views/users/likes.html.slim
+++ b/app/views/users/likes.html.slim
@@ -9,13 +9,13 @@
     = render 'relationships/follow_button', user: @user
   .col-xs-8
     ul.nav.nav-tabs.nav-justified
-      - is_active = "active" if current_page?(followings_user_path(@user))
+      - is_active = "active" if current_page?(likes_user_path(@user))
       li
         = link_to user_path(@user) do
           | Microposts
           span.badge
             = @count_microposts
-      li class=(is_active)
+      li
         = link_to followings_user_path(@user) do
           | Followings
           span.badge
@@ -25,9 +25,10 @@
           | Followers
           span.badge
             = @count_followers
-      li
+      li class=(is_active)
         = link_to likes_user_path(@user) do
-          | Likes
+          | likes
           span.badge
             = @count_like_microposts
-    = render 'users', users: @followings
+
+    = render 'microposts/microposts', microposts: @microposts

--- a/app/views/users/likes.html.slim
+++ b/app/views/users/likes.html.slim
@@ -27,7 +27,7 @@
             = @count_followers
       li class=(is_active)
         = link_to likes_user_path(@user) do
-          | likes
+          | Likes
           span.badge
             = @count_like_microposts
 

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -15,5 +15,19 @@
           | Microposts
           span.badge
             = @count_microposts
-      li Followings
-      li Followers
+      li
+        = link_to followings_user_path(@user) do
+          | Followings
+          span.badge
+            = @count_followings
+      li
+        = link_to followers_user_path(@user) do
+          | Followers
+          span.badge
+            = @count_followers
+      li
+        = link_to likes_user_path(@user) do
+          | Likes
+          span.badge
+            = @count_like_microposts
+    = render 'microposts/microposts', microposts: @microposts

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-
   root to: 'toppages#index'
 
   get 'login', to: 'sessions#new'
@@ -17,4 +16,6 @@ Rails.application.routes.draw do
   resources :microposts, only: [:create, :destroy]
 
   resources :relationships, only: [:create, :destroy]
+
+  resources :likes, only: [:create, :destroy]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,8 +8,7 @@ Rails.application.routes.draw do
   get 'signup', to: 'users#new'
   resources :users, only: [:index, :show, :new, :create] do
     member do
-      get :followings
-      get :followers
+      get :followings, :followers, :likes
     end
   end
 

--- a/db/migrate/20180810011920_create_likes.rb
+++ b/db/migrate/20180810011920_create_likes.rb
@@ -1,0 +1,11 @@
+class CreateLikes < ActiveRecord::Migration[5.0]
+  def change
+    create_table :likes do |t|
+      t.references :user, foreign_key: true
+      t.references :micropost, foreign_key: true
+
+      t.timestamps
+      t.index [:user_id, :micropost_id], unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180809084840) do
+ActiveRecord::Schema.define(version: 20180810011920) do
+
+  create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id"
+    t.integer  "micropost_id"
+    t.datetime "created_at",   null: false
+    t.datetime "updated_at",   null: false
+    t.index ["micropost_id"], name: "index_likes_on_micropost_id", using: :btree
+    t.index ["user_id", "micropost_id"], name: "index_likes_on_user_id_and_micropost_id", unique: true, using: :btree
+    t.index ["user_id"], name: "index_likes_on_user_id", using: :btree
+  end
 
   create_table "microposts", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.string   "content"
@@ -38,6 +48,8 @@ ActiveRecord::Schema.define(version: 20180809084840) do
     t.datetime "updated_at",      null: false
   end
 
+  add_foreign_key "likes", "microposts"
+  add_foreign_key "likes", "users"
   add_foreign_key "microposts", "users"
   add_foreign_key "relationships", "users"
   add_foreign_key "relationships", "users", column: "follow_id"


### PR DESCRIPTION
## 概要
[lesson-12 課題](https://techacademy.jp/my/rails/twitter-clone#kadai-fav)

## 仕様
- [x] 特定の Micropost をログインユーザがお気に入りリストに追加できるように、Micropostの表示の下にお気に入りボタンを設置してください。
- [x] そのボタンは、既にお気に入りに追加したものに対しては、外せるボタンとなるように工夫してください。（ヒント：カリキュラム内で作成したフォローボタンの一連の処理の流れを応用しましょう）
- [x] 指定のUser がお気に入りに追加した Micropost を、一覧表示するページを作成してください。また、トップページやナビバーからそのページにアクセスできるようにリンクを作成してください。
- [x] お気に入りした投稿一覧ページを表示させるアクションは/users/:id/likesとしてください。
- [x] GitHub に kadai-microposts でリモートリポジトリを作成して、プッシュしてください。
- [x] Herokuへデプロイしてください。